### PR TITLE
Disabling Jekyll

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,5 +3,5 @@
 title: The NobaNG Game
 description: Test and experiment of Python's gaming libraries and Amazon's cloud platforms.
 url: ""
-plugins:
-- jekyll-remote-theme # add this line to the plugins list if you already have one
+#plugins:
+#- jekyll-remote-theme # add this line to the plugins list if you already have one


### PR DESCRIPTION
Documentation works in local environment using sphinx and fails in the live version using GitHub-Pages and Jekyll. Disabling Jekyll as the most likely reason of the observed failure.